### PR TITLE
fix #3: span must not be global

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@chankamlam/express-jaeger",
-  "version": "1.1.29",
+  "version": "1.1.30",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chankamlam/express-jaeger",
-  "version": "1.1.29",
+  "version": "1.1.30",
   "description": "Jaeger middleware to request tracing for express application",
   "keywords": [
     "Jaeger",


### PR DESCRIPTION
This PR fixes #3 

Basically there are two major changes:

1. span was global
See removed lines 44 - 46. The span was global and "shared" between multiple requests. This only surfaces if the application is under big load. I moved the scope of the span to the express RequestHandler.

2. finishing the span
When I googled for this issue I stumbled upon this issue in the opentracing lib:
https://github.com/opentracing-contrib/javascript-express/issues/16
I adopted those changes and divided the finishing of the span to the two different events.